### PR TITLE
Refactor testing files to use helper method to print lists

### DIFF
--- a/qumulo/resource_ldap_server_test.go
+++ b/qumulo/resource_ldap_server_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -105,7 +104,7 @@ func testAccLdapServerConfig(ldap LdapServerSettingsBody) string {
      gid_number_attribute = %q
    }
    encrypt_connection = %v
- }`, ldap.UseLdap, ldap.BindUri, ldap.User, strings.ReplaceAll(fmt.Sprintf("%+q", ldap.BaseDistinguishedNames), "\" \"", "\", \""), ldap.LdapSchema, ldap.LdapSchemaDescription.GroupMemberAttribute,
+ }`, ldap.UseLdap, ldap.BindUri, ldap.User, PrintTerraformListFromString(ldap.BaseDistinguishedNames), ldap.LdapSchema, ldap.LdapSchemaDescription.GroupMemberAttribute,
 		ldap.LdapSchemaDescription.UserGroupIdentifierAttribute, ldap.LdapSchemaDescription.LoginNameAttribute, ldap.LdapSchemaDescription.GroupNameAttribute,
 		ldap.LdapSchemaDescription.UserObjectClass, ldap.LdapSchemaDescription.GroupObjectClass, ldap.LdapSchemaDescription.UidNumberAttribute, ldap.LdapSchemaDescription.GidNumberAttribute,
 		ldap.EncryptConnection)

--- a/qumulo/resource_nfs_export_test.go
+++ b/qumulo/resource_nfs_export_test.go
@@ -7,11 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 )
 
-func TestAccTestNfsExport(t *testing.T) {
+func TestAccCreateNfsExport(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -77,9 +76,9 @@ func defaultAccNfsExport(ne NfsExport) string {
    }
    fields_to_present_as_32_bit = %v
    allow_fs_path_create = true
- }`, ne.ExportPath, ne.FsPath, ne.Description, strings.ReplaceAll(fmt.Sprintf("%+q", ne.Restrictions[0].HostRestrictions), "\" \"", "\", \""), ne.Restrictions[0].ReadOnly,
+ }`, ne.ExportPath, ne.FsPath, ne.Description, PrintTerraformListFromList(ne.Restrictions[0].HostRestrictions), ne.Restrictions[0].ReadOnly,
 		ne.Restrictions[0].RequirePrivilegedPort, ne.Restrictions[0].UserMapping,
-		strings.ReplaceAll(fmt.Sprintf("%+q", ne.FieldsToPresentAs32Bit), "\" \"", "\", \""))
+		PrintTerraformListFromList(ne.FieldsToPresentAs32Bit))
 }
 
 func testAccNfsExport(ne NfsExport) string {
@@ -104,10 +103,10 @@ func testAccNfsExport(ne NfsExport) string {
    }
    fields_to_present_as_32_bit = %v
    allow_fs_path_create = true
- }`, ne.ExportPath, ne.FsPath, ne.Description, strings.ReplaceAll(fmt.Sprintf("%+q", ne.Restrictions[0].HostRestrictions), "\" \"", "\", \""), ne.Restrictions[0].ReadOnly,
+ }`, ne.ExportPath, ne.FsPath, ne.Description, PrintTerraformListFromList(ne.Restrictions[0].HostRestrictions), ne.Restrictions[0].ReadOnly,
 		ne.Restrictions[0].RequirePrivilegedPort, ne.Restrictions[0].UserMapping, ne.Restrictions[0].MapToUser["id_type"],
 		ne.Restrictions[0].MapToUser["id_value"], ne.Restrictions[0].MapToGroup["id_type"], ne.Restrictions[0].MapToGroup["id_value"],
-		strings.ReplaceAll(fmt.Sprintf("%+q", ne.FieldsToPresentAs32Bit), "\" \"", "\", \""))
+		PrintTerraformListFromList(ne.FieldsToPresentAs32Bit))
 }
 
 func testAccCompareNfsExports(ne NfsExport) resource.TestCheckFunc {

--- a/qumulo/resource_role_member_test.go
+++ b/qumulo/resource_role_member_test.go
@@ -3,7 +3,6 @@ package qumulo
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -61,7 +60,7 @@ resource "qumulo_role_member" "test_member" {
 	name = qumulo_local_user.test_user.name
 	role_name = qumulo_role.test_role.name
 }
-  `, role.Name, role.Description, strings.ReplaceAll(fmt.Sprintf("%+q", role.Privileges), "\" \"", "\", \""),
+  `, role.Name, role.Description, PrintTerraformListFromList(role.Privileges),
 		user.Name, user.PrimaryGroup, user.Uid, user.HomeDirectory, user.Password)
 }
 

--- a/qumulo/resource_role_test.go
+++ b/qumulo/resource_role_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -68,7 +67,7 @@ resource "qumulo_role" "test_role" {
 	description = %q
 	privileges  = %v
 }
-  `, role.Name, role.Description, strings.ReplaceAll(fmt.Sprintf("%+q", role.Privileges), "\" \"", "\", \""))
+  `, role.Name, role.Description, PrintTerraformListFromList(role.Privileges))
 }
 
 func testAccCompareRoleResource(role Role) resource.TestCheckFunc {

--- a/qumulo/resource_smb_server_test.go
+++ b/qumulo/resource_smb_server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -64,7 +63,7 @@ resource "qumulo_smb_server" "update_smb" {
 	bypass_traverse_checking = %v
 	signing_required = %v
 }
-  `, smb.SessionEncryption, strings.ReplaceAll(fmt.Sprintf("%+q", smb.SupportedDialects), "\" \"", "\", \""),
+  `, smb.SessionEncryption, PrintTerraformListFromList(smb.SupportedDialects),
 		smb.HideSharesFromUnauthorizedUsers, smb.HideSharesFromUnauthorizedHosts, smb.SnapshotDirectoryMode,
 		smb.BypassTraverseChecking, smb.SigningRequired)
 }

--- a/qumulo/resource_smb_share_test.go
+++ b/qumulo/resource_smb_share_test.go
@@ -3,7 +3,6 @@ package qumulo
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -105,11 +104,9 @@ resource "qumulo_smb_share" "share" {
 		access_based_enumeration_enabled = %v
 		require_encryption = %v
 	  }`, share1.ShareName, share1.FsPath, share1.Description, share1.Permissions[0].Type, share1.Permissions[0].Trustee.Name,
-	strings.ReplaceAll(fmt.Sprintf("%+q", share1.Permissions[0].Rights), "\" \"", "\", \""), share1.Permissions[1].Type,
-	share1.Permissions[1].Trustee.Name, strings.ReplaceAll(fmt.Sprintf("%+q", share1.Permissions[1].Rights), "\" \"", "\", \""),
-	share1.NetworkPermissions[0].Type, "[]",
-	strings.ReplaceAll(fmt.Sprintf("%+q", share1.NetworkPermissions[0].Rights), "\" \"", "\", \""),
-	share1.AccessBasedEnumEnabled, share1.RequireEncryption)
+	PrintTerraformListFromList(share1.Permissions[0].Rights), share1.Permissions[1].Type, share1.Permissions[1].Trustee.Name,
+	PrintTerraformListFromList(share1.Permissions[1].Rights), share1.NetworkPermissions[0].Type, "[]",
+	PrintTerraformListFromList(share1.NetworkPermissions[0].Rights), share1.AccessBasedEnumEnabled, share1.RequireEncryption)
 
 var share1Updated = SmbShare{
 	ShareName:   "ShareForTesting",
@@ -181,13 +178,11 @@ resource "qumulo_smb_share" "share" {
 		access_based_enumeration_enabled = %v
 		require_encryption = %v
 	  }`, share1Updated.ShareName, share1Updated.FsPath, share1Updated.Description, share1Updated.Permissions[0].Type,
-	share1Updated.Permissions[0].Trustee.Name,
-	strings.ReplaceAll(fmt.Sprintf("%+q", share1Updated.Permissions[0].Rights), "\" \"", "\", \""),
+	share1Updated.Permissions[0].Trustee.Name, PrintTerraformListFromList(share1Updated.Permissions[0].Rights),
 	share1Updated.Permissions[1].Type, share1Updated.Permissions[1].Trustee.Name,
-	strings.ReplaceAll(fmt.Sprintf("%+q", share1Updated.Permissions[1].Rights), "\" \"", "\", \""),
-	share1Updated.NetworkPermissions[0].Type, "[]",
-	strings.ReplaceAll(fmt.Sprintf("%+q", share1Updated.NetworkPermissions[0].Rights), "\" \"", "\", \""),
-	share1Updated.AccessBasedEnumEnabled, share1Updated.RequireEncryption)
+	PrintTerraformListFromList(share1Updated.Permissions[1].Rights), share1Updated.NetworkPermissions[0].Type, "[]",
+	PrintTerraformListFromList(share1Updated.NetworkPermissions[0].Rights), share1Updated.AccessBasedEnumEnabled,
+	share1Updated.RequireEncryption)
 
 func testAccCompareShare(share SmbShare) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(

--- a/qumulo/resource_time_configuration_test.go
+++ b/qumulo/resource_time_configuration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -50,7 +49,7 @@ func testAccTimeConfigurationConfig(req TimeConfigurationBody) string {
 		use_ad_for_primary = %v
 		ntp_servers = %v
 	}
-  `, req.UseAdForPrimary, strings.ReplaceAll(fmt.Sprintf("%+q", req.NtpServers), "\" \"", "\", \""))
+  `, req.UseAdForPrimary, PrintTerraformListFromList(req.NtpServers))
 }
 
 func testAccCheckTimeConfiguration(timeConfig TimeConfigurationBody) resource.TestCheckFunc {

--- a/qumulo/utils.go
+++ b/qumulo/utils.go
@@ -58,6 +58,14 @@ func InterfaceSliceToStringSlice(interfaceSlice []interface{}) []string {
 	return stringSlice
 }
 
+func PrintTerraformListFromList(list []string) string {
+	return strings.ReplaceAll(fmt.Sprintf("%+q", list), "\" \"", "\", \"")
+}
+
+func PrintTerraformListFromString(str string) string {
+	return strings.ReplaceAll(fmt.Sprintf("%+q", str), "\" \"", "\", \"")
+}
+
 func ParseLocalGroupMemberId(id string) ([]string, error) {
 	ids := strings.Split(id, ":")
 	if len(ids) != 2 {


### PR DESCRIPTION
Now, test files don't need the lovely massive `strings.ReplaceAll` call!